### PR TITLE
Refactor exception message formatting in AbstractConverter

### DIFF
--- a/src/Converters/AbstractConverter.php
+++ b/src/Converters/AbstractConverter.php
@@ -36,7 +36,7 @@ abstract class AbstractConverter
      */
     public function toInternal(string $source): SourceSuite
     {
-        throw new Exception('Method \"' . __METHOD__ . '\" is not available');
+        throw new Exception('Method "' . __METHOD__ . '" is not available');
     }
 
     /**
@@ -45,7 +45,7 @@ abstract class AbstractConverter
      */
     public function fromInternal(SourceSuite $sourceSuite): string
     {
-        throw new Exception('Method \"' . __METHOD__ . '\" is not available');
+        throw new Exception('Method "' . __METHOD__ . '" is not available');
     }
 
     public function setRootPath(string $rootPath): self


### PR DESCRIPTION
Altered the syntax used to generate exception messages within the `toInternal` and `fromInternal` methods in `AbstractConverter.php`. This change replaces the previous escaped double quotes with unescaped ones, thereby improving the readability of the generated messages.