### PR TITLE
docs(dev-guide): Add Claude AI guidance and update documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ vendor
 phpunit.xml
 *.cache
 ci-report-converter.phar
+.claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,84 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+CI-Report-Converter is a PHP library that converts error reports between different formats for better integration with CI systems and IDEs. It transforms reports from tools like PHPcs, PHPmd, Psalm, PHPStan into formats compatible with TeamCity, GitHub Actions, JetBrains IDEs, and other platforms.
+
+## Development Commands
+
+### Essential Commands
+- `make build` - Install dependencies and build phar file
+- `make test` - Run PHPUnit tests
+- `make test-all` - Run tests and code style checks
+- `make codestyle` - Run code style analysis (via jbzoo/codestyle)
+
+### Testing Commands
+- `php ./vendor/bin/phpunit` - Run PHPUnit tests directly
+- `php ./vendor/bin/phpunit --configuration ./phpunit.xml.dist` - Run with specific config
+- `make test-example` - Run example tests and generate fixtures
+
+### Building
+- `make build-phar` - Build standalone phar executable
+- `make build-docker` - Build Docker image
+- `make create-symlink` - Create symlink for testing
+
+### The main binary
+- `./ci-report-converter` - Main CLI executable (symlinked via make create-symlink)
+- `./vendor/bin/ci-report-converter` - Alternative path to CLI
+
+## Architecture
+
+### Core Components
+
+1. **Converters** (`src/Converters/`) - Transform input formats to internal representation
+   - Input converters: CheckStyle, JUnit, PHPmd-JSON, PHPmnd, Psalm-JSON, PMD-CPD
+   - Output converters: TeamCity Tests/Inspections, GitHub CLI, GitLab JSON, JUnit, Plain Text
+   - Stats converters: Extract metrics for TeamCity statistics
+
+2. **Formats** (`src/Formats/`) - Define data structures for different report formats
+   - `Source/` - Internal canonical format (SourceSuite, SourceCase, SourceCaseOutput)
+   - `JUnit/` - JUnit XML format classes
+   - `TeamCity/` - TeamCity service messages format
+   - `GithubActions/` - GitHub Actions annotations format
+   - `MetricMaps/` - Metric extraction from various tools
+
+3. **Commands** (`src/Commands/`) - CLI command implementations
+   - `Convert` - Main conversion command
+   - `TeamCityStats` - Extract and report code metrics
+   - `AbstractCommand` - Base command class
+
+### Conversion Flow
+
+1. Input format → Internal Source format (SourceSuite/SourceCase)
+2. Internal format → Target output format
+3. Output written to file or stdout
+
+### Key Classes
+
+- `Map` - Registry of available input/output converters
+- `Helper` - Utility functions for path manipulation and validation
+- `AbstractConverter` - Base converter with common functionality
+
+## Testing
+
+- Tests located in `tests/` directory
+- PHPUnit configuration: `phpunit.xml.dist`
+- Coverage reports generated in `build/coverage_*`
+- Fixture files in `tests/fixtures/` for various input/output formats
+
+## Dependencies
+
+- PHP 8.2+ required
+- Symfony Console for CLI interface
+- JBZoo packages (cli, data, utils, markdown)
+- Development dependencies include jbzoo/toolbox-dev for code quality tools
+
+## File Structure
+
+- `src/` - Main source code
+- `tests/` - Test files and fixtures
+- `ci-report-converter` - Main executable (shell script wrapper)
+- `Makefile` - Build and development commands
+- `composer.json` - Dependency and autoload configuration

--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ Well... It may seem to you it's a useless thing, and _your favorite super tool_ 
 
 
 
+## Requirements
+
+- PHP 8.2 or higher
+- Extensions: dom, simplexml, hash
+
 ## Installing
 
 ```shell
@@ -132,7 +137,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.2
+          tools: composer
+
+      - name: Install Dependencies
+        run: composer install
 
       - name: PHP Code Sniffer
         run: ./vendor/bin/phpcs --report=checkstyle --standard=PSR12 -q ./src > ./build/phpcs-checkstyle.xml
@@ -555,9 +569,9 @@ You can find a lot of [life examples here](https://github.com/JBZoo/CI-Report-Co
 
 ### GitLab CI
 
-Use the option `--output-format=gitlab-json` to convert the report to Gitlab JSON format.
+Use the option `--output-format=gitlab-json` to convert the report to GitLab JSON format.
 
-Als, see [how to implemente GitLab Custom Report](https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html#implementing-a-custom-tool)
+Also, see [how to implement GitLab Custom Report](https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html#implementing-a-custom-tool)
 
 ![GitLab Code Quality Report](.github/assets/gitlab-code-quality-report.png)
 


### PR DESCRIPTION
- Introduce CLAUDE.md to provide specific context and instructions for AI tools like Claude Code, enhancing their ability to assist with development.
- Update README.md with explicit PHP version and extension requirements.
- Modernize GitHub Actions workflow example in README.md:
  - Upgrade `actions/checkout` to v4.
  - Add `shivammathur/setup-php` for PHP 8.2 and Composer setup.
  - Include `composer install` step for dependencies.
- Correct typos in README.md ("implemente" to "implement", "Gitlab" to "GitLab").
- Add `.claude` to .gitignore to prevent temporary AI-generated files from being committed.